### PR TITLE
Caddy 2

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+skip_list:
+  - '106'  # Role name caddy-ansible does not match `^[a-z][a-z0-9_]+$` pattern

--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@
 - [Role Variables](#role-variables)
   * [The Caddyfile](#the-caddyfile)
   * [The OS to download caddy for](#the-os-to-download-caddy-for)
-  * [The type of license to use](#the-type-of-license-to-use)
   * [Auto update Caddy?](#auto-update-caddy)
-  * [Additional Available Features](#additional-available-features)
+  * [Additional Available Packages](#additional-available-packages)
   * [Use `setcap`?](#use-setcap)
   * [Verify the PGP signature on download?](#verify-the-pgp-signature-on-download)
   * [Use systemd capabilities controls](#use-systemd-capabilities-controls)
@@ -56,21 +55,6 @@ default:
 
 ```yaml
 caddy_os: linux
-```
-
-### The type of license to use
-
-default:
-
-```yaml
-caddy_license: personal
-```
-
-If you set the license type to `commercial` then you should also specify (replacing the dummy values with your real ones):
-
-```yaml
-caddy_license_account_id: YOUR_ACCOUNT_ID
-caddy_license_api_key: YOUR_API_KEY
 ```
 
 ### Auto update Caddy?

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ caddy_license_api_key: YOUR_API_KEY
 default:
 
 ```yaml
-caddy_update: yes
+caddy_update: true
 ```
 
 ### Additional Available Packages
@@ -98,7 +98,7 @@ This allows Caddy to open a low port (under 1024 - e.g. 80, 443).
 default:
 
 ```yaml
-caddy_setcap: yes
+caddy_setcap: true
 ```
 
 ### Verify the PGP signature on download?
@@ -106,7 +106,7 @@ caddy_setcap: yes
 default:
 
 ```yaml
-caddy_pgp_verify_signatures: no
+caddy_pgp_verify_signatures: false
 ```
 
 ### Use systemd capabilities controls
@@ -114,7 +114,7 @@ caddy_pgp_verify_signatures: no
 default:
 
 ```yaml
-caddy_systemd_capabilities_enabled: False
+caddy_systemd_capabilities_enabled: false
 caddy_systemd_capabilities: "CAP_NET_BIND_SERVICE"
 ```
 
@@ -200,7 +200,6 @@ Example with Cloudflare DNS for TLS:
         CLOUDFLARE_API_KEY: 1234567890
       caddy_config: |
         yourcloudflareddomain.com {
-
             tls {
                 dns cloudflare
             }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
   * [Auto update Caddy?](#auto-update-caddy)
   * [Additional Available Packages](#additional-available-packages)
   * [Use `setcap`?](#use-setcap)
-  * [Verify the PGP signature on download?](#verify-the-pgp-signature-on-download)
   * [Use systemd capabilities controls](#use-systemd-capabilities-controls)
   * [Add additional environment variables](#add-additional-environment-variables)
   * [Use additional CLI arguments](#use-additional-cli-arguments)
@@ -83,14 +82,6 @@ default:
 
 ```yaml
 caddy_setcap: true
-```
-
-### Verify the PGP signature on download?
-
-default:
-
-```yaml
-caddy_pgp_verify_signatures: false
 ```
 
 ### Use systemd capabilities controls

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   * [Use systemd capabilities controls](#use-systemd-capabilities-controls)
   * [Add additional environment variables](#add-additional-environment-variables)
   * [Use additional CLI arguments](#use-additional-cli-arguments)
+  * [Use a GitHub OAuth token to request the list of caddy releases](#use-a-github-oauth-token-to-request-the-list-of-caddy-releases)
 - [Example Playbooks](#example-playbooks)
 - [Debugging](#debugging)
 - [Contributing](#contributing)
@@ -161,6 +162,16 @@ Example for LetsEncrypt staging:
 
 ```yaml
 caddy_additional_args: "-ca https://acme-staging.api.letsencrypt.org/directory"
+```
+
+### Use a GitHub OAuth token to request the list of caddy releases
+
+This role uses the GitHub releases list to check when a new version is available. [GitHub has some fairly agressive rate-limiting](https://developer.github.com/v3/#rate-limiting) which can cause failures. You can set your GitHub token to increase the limits for yourself when running the role (e.g. if deploying many servers behind a NAT or running this role repeatedly as part of a CI process).
+
+default:
+
+```yaml
+caddy_github_token: ""
 ```
 
 ## Example Playbooks

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@
 - [Dependencies](#dependencies)
 - [Role Variables](#role-variables)
   * [The Caddyfile](#the-caddyfile)
+  * [The OS to download caddy for](#the-os-to-download-caddy-for)
   * [The type of license to use](#the-type-of-license-to-use)
   * [Auto update Caddy?](#auto-update-caddy)
-  * [Features that can be added to core](#features-that-can-be-added-to-core)
+  * [Additional Available Features](#additional-available-features)
   * [Use `setcap`?](#use-setcap)
   * [Verify the PGP signature on download?](#verify-the-pgp-signature-on-download)
   * [Use systemd capabilities controls](#use-systemd-capabilities-controls)
@@ -39,17 +40,22 @@ default:
 
 ```yaml
 caddy_config: |
-  localhost:2020
-  gzip
-  # tls email@example.com
-  root /var/www
-  git github.com/antoiner77/caddy-ansible
+  http://localhost:2020
+  respond "Hello, world!"
 ```
 
 If you wish to use a template for the config you can do this:
 
 ```yaml
 caddy_config: "{{ lookup('template', 'templates/Caddyfile.j2') }}"
+```
+
+### The OS to download caddy for
+
+default:
+
+```yaml
+caddy_os: linux
 ```
 
 ### The type of license to use
@@ -75,24 +81,14 @@ default:
 caddy_update: yes
 ```
 
-### Features that can be added to core
+### Additional Available Packages
 
-http.authz, http.awses, http.awslambda, http.cache, http.cgi, http.cors,
-http.datadog, http.expires, http.filebrowser, http.filter, http.forwardproxy,
-http.git, http.gopkg, http.grpc, http.hugo, http.ipfilter, http.jekyll, http.jwt,
-http.locale, http.login, http.mailout, http.minify, http.nobots, http.prometheus,
-http.proxyprotocol, http.ratelimit, http.realip, http.reauth, http.restic,
-http.upload, http.webdav, dns, net, hook.service, tls.dns.azure, tls.dns.cloudflare,
-tls.dns.digitalocean, tls.dns.dnsimple, tls.dns.dnspod, tls.dns.dyn, tls.dns.exoscale,
-tls.dns.gandi, tls.dns.googlecloud, tls.dns.linode, tls.dns.namecheap, tls.dns.ovh,
-tls.dns.rackspace, tls.dns.rfc2136, tls.dns.route53, tls.dns.vultr
-
-Changing this variable will reinstall Caddy with the new features if `caddy_update` is enabled.
+Changing this variable will reinstall Caddy with the new packages if `caddy_update` is enabled. Check https://caddyserver.com/download for available packages.
 
 default:
 
 ```yaml
-caddy_features: http.git
+caddy_packages: []
 ```
 
 ### Use `setcap`?

--- a/README.md
+++ b/README.md
@@ -1,21 +1,42 @@
 [![Build Status](https://travis-ci.org/caddy-ansible/caddy-ansible.svg?branch=master)](https://travis-ci.org/caddy-ansible/caddy-ansible)
 [![Galaxy Role](https://img.shields.io/badge/ansible--galaxy-caddy-blue.svg)](https://galaxy.ansible.com/caddy_ansible/caddy_ansible/)
 
-Caddy Ansible Role
-=========
+# Caddy Ansible Role
+
+<!-- toc -->
+
+- [Dependencies](#dependencies)
+- [Role Variables](#role-variables)
+  * [The Caddyfile](#the-caddyfile)
+  * [The type of license to use](#the-type-of-license-to-use)
+  * [Auto update Caddy?](#auto-update-caddy)
+  * [Features that can be added to core](#features-that-can-be-added-to-core)
+  * [Use `setcap`?](#use-setcap)
+  * [Verify the PGP signature on download?](#verify-the-pgp-signature-on-download)
+  * [Use systemd capabilities controls](#use-systemd-capabilities-controls)
+  * [Add additional environment variables](#add-additional-environment-variables)
+  * [Use additional CLI arguments](#use-additional-cli-arguments)
+- [Example Playbooks](#example-playbooks)
+- [Debugging](#debugging)
+- [Contributing](#contributing)
+
+<!-- tocstop -->
 
 This role installs and configures the caddy web server. The user can specify any http configuration parameters they wish to apply their site. Any number of sites can be added with configurations of your choice.
 
-Dependencies
-------------
+## Dependencies
+
 None
 
-Role Variables
---------------
+## Role Variables
 
-**The [Caddyfile](https://caddyserver.com/docs/caddyfile)** (notice the pipe)<br>
+### The Caddyfile
+
+See [Caddyfile docs](https://caddyserver.com/docs/caddyfile). Notice the `|` used to include a multi-line string.
+
 default:
-```
+
+```yaml
 caddy_config: |
   localhost:2020
   gzip
@@ -25,89 +46,126 @@ caddy_config: |
 ```
 
 If you wish to use a template for the config you can do this:
-```
+
+```yaml
 caddy_config: "{{ lookup('template', 'templates/Caddyfile.j2') }}"
 ```
 
-**The type of license to use**<br>
+### The type of license to use
+
 default:
-```
+
+```yaml
 caddy_license: personal
 ```
+
 If you set the license type to `commercial` then you should also specify (replacing the dummy values with your real ones):
-```
+
+```yaml
 caddy_license_account_id: YOUR_ACCOUNT_ID
 caddy_license_api_key: YOUR_API_KEY
 ```
-**Auto update Caddy?**<br>
+
+### Auto update Caddy?
+
 default:
-```
+
+```yaml
 caddy_update: yes
 ```
-**Features that can be added to core:** http.authz, http.awses, http.awslambda,
-http.cache, http.cgi, http.cors, http.datadog, http.expires, http.filebrowser,
-http.filter, http.forwardproxy, http.git, http.gopkg, http.grpc, http.hugo,
-http.ipfilter, http.jekyll, http.jwt, http.locale, http.login, http.mailout,
-http.minify, http.nobots, http.prometheus, http.proxyprotocol, http.ratelimit,
-http.realip, http.reauth, http.restic, http.upload, http.webdav, dns, net,
-hook.service, tls.dns.azure, tls.dns.cloudflare, tls.dns.digitalocean,
-tls.dns.dnsimple, tls.dns.dnspod, tls.dns.dyn, tls.dns.exoscale, tls.dns.gandi,
-tls.dns.googlecloud, tls.dns.linode, tls.dns.namecheap, tls.dns.ovh,
+
+### Features that can be added to core
+
+http.authz, http.awses, http.awslambda, http.cache, http.cgi, http.cors,
+http.datadog, http.expires, http.filebrowser, http.filter, http.forwardproxy,
+http.git, http.gopkg, http.grpc, http.hugo, http.ipfilter, http.jekyll, http.jwt,
+http.locale, http.login, http.mailout, http.minify, http.nobots, http.prometheus,
+http.proxyprotocol, http.ratelimit, http.realip, http.reauth, http.restic,
+http.upload, http.webdav, dns, net, hook.service, tls.dns.azure, tls.dns.cloudflare,
+tls.dns.digitalocean, tls.dns.dnsimple, tls.dns.dnspod, tls.dns.dyn, tls.dns.exoscale,
+tls.dns.gandi, tls.dns.googlecloud, tls.dns.linode, tls.dns.namecheap, tls.dns.ovh,
 tls.dns.rackspace, tls.dns.rfc2136, tls.dns.route53, tls.dns.vultr
 
-Changing this variable will reinstall Caddy with the new features if `caddy_update` is enabled<br>
+Changing this variable will reinstall Caddy with the new features if `caddy_update` is enabled.
+
 default:
-```
+
+```yaml
 caddy_features: http.git
 ```
-**Use `setcap` for allowing Caddy to open a low port (e.g. 80, 443)?**<br>
+
+### Use `setcap`?
+
+This allows Caddy to open a low port (under 1024 - e.g. 80, 443).
+
 default:
-```
+
+```yaml
 caddy_setcap: yes
 ```
-**Verify the PGP signature on download?**<br>
-```
+
+### Verify the PGP signature on download?
+
+default:
+
+```yaml
 caddy_pgp_verify_signatures: no
 ```
-**Use systemd capabilities controls**<br>
+
+### Use systemd capabilities controls
+
 default:
-```
+
+```yaml
 caddy_systemd_capabilities_enabled: False
 caddy_systemd_capabilities: "CAP_NET_BIND_SERVICE"
 ```
+
 NOTE: This feature requires systemd v229 or newer and might be needed in addition to `caddy_setcap: yes`.
 
 Supported:
+
 * Debian 9 (stretch)
 * Fedora 25
 * Ubuntu 16.04 (xenial)
 
 RHEL/CentOS has no release that supports systemd capability controls at this time.
 
-**Add additional environment variables**<br>
+### Add additional environment variables
 
-Add environment variables to the systemd script
+Add environment variables to the systemd script.
 
+default:
+
+```yaml
+caddy_environment_variables: {}
 ```
+
+Example usage:
+
+```yaml
 caddy_environment_variables:
   FOO: bar
   SECONDVAR: spam
 ```
 
-**Use additional cli arguments**<br>
+### Use additional CLI arguments
+
 default:
-```
+
+```yaml
 caddy_additional_args: ""
 ```
-Example for Letsencrypt staging:
-```
+
+Example for LetsEncrypt staging:
+
+```yaml
 caddy_additional_args: "-ca https://acme-staging.api.letsencrypt.org/directory"
 ```
 
+## Example Playbooks
 
-Example Playbooks
-----------------
-```
+```yaml
 ---
 - hosts: all
   roles:
@@ -122,9 +180,9 @@ Example Playbooks
         git github.com/antoiner77/caddy-ansible
 ```
 
-Example with Cloudflare DNS for TLS
+Example with Cloudflare DNS for TLS:
 
-```
+```yaml
 ---
 - hosts: all
   roles:
@@ -147,21 +205,22 @@ Example with Cloudflare DNS for TLS
         }
 ```
 
-Debugging
----------
-If the service fails to start you can figure out why by looking at the output of Caddy.<br>
+## Debugging
 
-```console
+If the service fails to start you can figure out why by looking at the output of Caddy.
+
+```bash
 systemctl status caddy -l
 ```
 
 If something doesn't seem right, open an issue!
 
-Contributing
-------------
+## Contributing
+
 Pull requests are welcome. Please test your changes beforehand with vagrant:
-```
+
+```bash
 vagrant up
-vagrant provision (since it already provisioned there should be no changes here)
+vagrant provision   # (since it already provisioned there should be no changes here)
 vagrant destroy
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,12 +10,16 @@ Vagrant.configure(2) do |config|
     bionic.vm.box = "bento/ubuntu-18.04"
   end
 
-  config.vm.define "centos7" do |centos7|
-    centos7.vm.box = "bento/centos-7.3"
+  config.vm.define "focal" do |focal|
+    focal.vm.box = "bento/ubuntu-20.04"
   end
 
-  config.vm.define "fedora29" do |fedora29|
-    fedora29.vm.box = "bento/fedora-29"
+  config.vm.define "centos7" do |centos7|
+    centos7.vm.box = "bento/centos-7.6"
+  end
+
+  config.vm.define "fedora32" do |fedora32|
+    fedora32.vm.box = "bento/fedora-32"
   end
 
   config.vm.provision "ansible" do |ansible|
@@ -31,8 +35,8 @@ Vagrant.configure(2) do |config|
   http_code=$(curl --silent --head --output /dev/null -w '%{http_code}' localhost:2020)
   case $http_code in
     200|404) echo "$http_code | Server running" ;;
-    000)     echo "$http_code | Server not accessible!" >&2 ;;
-    *)       echo "$http_code | Unknown http response code!" >&2 ;;
+    000)     echo "$http_code | Server not accessible!" >&2 ; exit 1 ;;
+    *)       echo "$http_code | Unknown http response code!" >&2 ; exit 1 ;;
   esac
 SCRIPT
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = 'tests/playbook.yml'
+    ansible.verbose = true
   end
 
   $script = <<SCRIPT

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ caddy_features: http.git
 caddy_update: true
 caddy_bin_dir: /usr/local/bin
 caddy_conf_dir: /etc/caddy
+caddy_github_token: ""
 caddy_license: personal
 caddy_license_account_id:
 caddy_license_api_key:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for caddy-ansible
 caddy_user: www-data
 caddy_home: /home/caddy
-caddy_features: http.git
+caddy_packages: []
 caddy_update: true
 caddy_bin_dir: /usr/local/bin
 caddy_conf_dir: /etc/caddy
@@ -34,9 +34,7 @@ caddy_pgp_key_server: hkp://keyserver.ubuntu.com
 caddy_pgp_recv_timeout: 60
 caddy_pgp_verify_signatures: false
 caddy_config: |
-  localhost:2020
-  gzip
-  # tls email@example.com
-  # root /var/www
-  git github.com/antoiner77/caddy-ansible
+  http://localhost:2020
+  respond "Hello, world!"
 caddy_environment_variables: {}
+caddy_os: linux

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,5 +38,4 @@ caddy_config: |
   # tls email@example.com
   # root /var/www
   git github.com/antoiner77/caddy-ansible
-
 caddy_environment_variables: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,9 +7,6 @@ caddy_update: true
 caddy_bin_dir: /usr/local/bin
 caddy_conf_dir: /etc/caddy
 caddy_github_token: ""
-caddy_license: personal
-caddy_license_account_id:
-caddy_license_api_key:
 caddy_log_dir: /var/log/caddy
 caddy_log_file: stdout
 caddy_certs_dir: /etc/ssl/caddy

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,10 +26,6 @@ caddy_systemd_protect_home: "false"
 caddy_systemd_protect_system: "full"
 caddy_systemd_nproc_limit: 0
 caddy_setcap: true
-caddy_pgp_key_id: 65760C51EDEA2017CEA2CA15155B6D79CA56EA34
-caddy_pgp_key_server: hkp://keyserver.ubuntu.com
-caddy_pgp_recv_timeout: 60
-caddy_pgp_verify_signatures: false
 caddy_config: |
   http://localhost:2020
   respond "Hello, world!"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,12 @@
 ---
-# handlers file for caddy-ansible
-- name: restart caddy
+
+- name: Restart caddy
   systemd:
     daemon_reload: true
     name: caddy
     state: restarted
 
-- name: reload caddy
+- name: Reload caddy
   systemd:
     name: caddy
     state: reloaded

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,9 +18,7 @@ def test_files(host):
 
 
 def test_packages(host):
-    pkgs = [
-        "git"
-    ]
+    pkgs = []
     for p in pkgs:
         assert host.package(p).is_installed
 

--- a/tasks/github-extract.yml
+++ b/tasks/github-extract.yml
@@ -4,7 +4,9 @@
     src: "{{ caddy_home }}/caddy.tar.gz"
     dest: "{{ caddy_home }}"
     copy: false
+    mode: 0644
     owner: "{{ caddy_user }}"
+    group: "{{ caddy_user_details.group }}"
   when: caddy_binary_cache.changed
   tags: skip_ansible_lint
 
@@ -14,4 +16,6 @@
     dest: "{{ caddy_home }}"
     creates: "{{ caddy_home }}/caddy"
     copy: false
+    mode: 0644
     owner: "{{ caddy_user }}"
+    group: "{{ caddy_user_details.group }}"

--- a/tasks/github-extract.yml
+++ b/tasks/github-extract.yml
@@ -1,0 +1,17 @@
+---
+- name: Extract Caddy
+  unarchive:
+    src: "{{ caddy_home }}/caddy.tar.gz"
+    dest: "{{ caddy_home }}"
+    copy: false
+    owner: "{{ caddy_user }}"
+  when: caddy_binary_cache.changed
+  tags: skip_ansible_lint
+
+- name: Extract Caddy
+  unarchive:
+    src: "{{ caddy_home }}/caddy.tar.gz"
+    dest: "{{ caddy_home }}"
+    creates: "{{ caddy_home }}/caddy"
+    copy: false
+    owner: "{{ caddy_user }}"

--- a/tasks/github-url.yml
+++ b/tasks/github-url.yml
@@ -1,0 +1,19 @@
+---
+- name: Get latest Caddy release details
+  uri:
+    url: https://api.github.com/repos/mholt/caddy/releases/latest
+    return_content: true
+    headers: '{{ caddy_github_headers }}'
+  register: latest_caddy_release
+
+- name: Set Caddy tag
+  set_fact:
+    caddy_tag: "{{ (latest_caddy_release.content | from_json).get('tag_name') }}"
+
+- name: Set Caddy version
+  set_fact:
+    caddy_version: "{{ caddy_tag | regex_replace('^v', '') }}"
+
+- name: Set Caddy url
+  set_fact:
+    caddy_url: "https://github.com/caddyserver/caddy/releases/download/{{ caddy_tag }}/caddy_{{ caddy_version }}_{{ caddy_os }}_{{ go_arch }}.tar.gz"

--- a/tasks/github-url.yml
+++ b/tasks/github-url.yml
@@ -16,4 +16,5 @@
 
 - name: Set Caddy url
   set_fact:
-    caddy_url: "https://github.com/caddyserver/caddy/releases/download/{{ caddy_tag }}/caddy_{{ caddy_version }}_{{ caddy_os }}_{{ go_arch }}.tar.gz"
+    caddy_url: "https://github.com/caddyserver/caddy/releases/download/\
+                {{ caddy_tag }}/caddy_{{ caddy_version }}_{{ caddy_os }}_{{ go_arch }}.tar.gz"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Build headers to use when making requests to github
   set_fact:
     caddy_github_headers: "{{ caddy_github_headers | combine({'Authorisation': 'token ' + caddy_github_token}) }}"
-  when: caddy_github_token != ""
+  when: caddy_github_token | length > 0
 
 - name: Get all Caddy releases
   get_url:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,11 +9,17 @@
     createhome: true
     home: "{{ caddy_home }}"
 
+- name: Build headers to use when making requests to github
+  set_fact:
+    caddy_github_headers: "{{ caddy_github_headers | combine({'Authorisation': 'token ' + caddy_github_token}) }}"
+  when: caddy_github_token != ""
+
 - name: Get all Caddy releases
   get_url:
     url: https://api.github.com/repos/mholt/caddy/git/refs/tags
     dest: "{{ caddy_home }}/releases.txt"
     force: true
+    headers: '{{ caddy_github_headers }}'
   retries: 3
   delay: 2
   when: caddy_update

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,25 +35,6 @@
 - name: Set some common parameters
   set_fact:
     caddy_bin_name: "caddy_{{ caddy_os }}_{{ go_arch }}"
-    caddy_common_args: "os={{ caddy_os }}&arch={{ go_arch }}&license={{ caddy_license }}\
-                        {% for pkg in caddy_packages %}\
-                        {% if loop.first %}&{% endif %}p={{ pkg }}{% if not loop.last %},{% endif %}\
-                        {% endfor %}"
-
-- name: Build base URL
-  set_fact:
-    caddy_base_url: "https://{{ caddy_auth_info }}@caddyserver.com/api/download"
-  when: caddy_license != 'personal'
-
-- name: Build base URL
-  set_fact:
-    caddy_base_url: "https://caddyserver.com/api/download"
-  when: caddy_license == 'personal'
-
-- name: Build request URLs
-  set_fact:
-    caddy_url: "{{ caddy_base_url }}?{{ caddy_common_args }}"
-    caddy_sig_url: "{{ caddy_base_url }}/signature?{{ caddy_common_args }}"
 
 - name: Download Caddy
   get_url:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,30 +27,36 @@
 
 - name: Set Caddy features
   copy:
-    content: "{{ caddy_features }}"
+    content: "{{ ','.join(caddy_packages) }}"
     dest: "{{ caddy_home }}/features.txt"
   when: caddy_update
   register: caddy_features_cache
 
+- name: Set some common parameters
+  set_fact:
+    caddy_bin_name: "caddy_{{ caddy_os }}_{{ go_arch }}"
+    caddy_common_args: "os={{ caddy_os }}&arch={{ go_arch }}&license={{ caddy_license }}\
+                        {% for pkg in caddy_packages %}{% if loop.first %}&{% endif %}p={{ pkg }}{% if not loop.last %},{% endif %}{% endfor %}"
+
 - name: Build base URL
   set_fact:
-    caddy_base_url: "https://{{ caddy_auth_info }}@caddyserver.com/download/linux/{{ go_arch }}"
+    caddy_base_url: "https://{{ caddy_auth_info }}@caddyserver.com/api/download"
   when: caddy_license != 'personal'
 
 - name: Build base URL
   set_fact:
-    caddy_base_url: "https://caddyserver.com/download/linux/{{ go_arch }}"
+    caddy_base_url: "https://caddyserver.com/api/download"
   when: caddy_license == 'personal'
 
 - name: Build request URLs
   set_fact:
-    caddy_url: "{{ caddy_base_url }}?plugins={{ caddy_features }}&license={{ caddy_license }}"
-    caddy_sig_url: "{{ caddy_base_url }}/signature?plugins={{ caddy_features }}&license={{ caddy_license }}"
+    caddy_url: "{{ caddy_base_url }}?{{ caddy_common_args }}"
+    caddy_sig_url: "{{ caddy_base_url }}/signature?{{ caddy_common_args }}"
 
 - name: Download Caddy
   get_url:
     url: "{{ caddy_url }}"
-    dest: "{{ caddy_home }}/caddy.tar.gz"
+    dest: "{{ caddy_home }}/{{ caddy_bin_name }}"
     force_basic_auth: "{{ caddy_license != 'personal' }}"
     force: true
     timeout: 300
@@ -63,7 +69,7 @@
 - name: Download Caddy
   get_url:
     url: "{{ caddy_url }}"
-    dest: "{{ caddy_home }}/caddy.tar.gz"
+    dest: "{{ caddy_home }}/{{ caddy_bin_name }}"
     force_basic_auth: "{{ caddy_license != 'personal' }}"
     timeout: 300
   retries: 3
@@ -93,40 +99,23 @@
   changed_when: '"imported" in caddy_pgp_key.stdout'
   tags: skip_ansible_lint
 
-- name: Download Caddy signature
-  get_url:
-    url: "{{ caddy_sig_url }}"
-    dest: "{{ caddy_home }}/caddy.tar.gz.asc"
-    timeout: 60
-    force: true
-    force_basic_auth: "{{ caddy_license != 'personal' }}"
-  when: caddy_pgp_verify_signatures and (caddy_binary_cache.changed or caddy_download.changed)
-  tags: skip_ansible_lint
+# - name: Download Caddy signature
+#   get_url:
+#     url: "{{ caddy_sig_url }}"
+#     dest: "{{ caddy_home }}/caddy.tar.gz.asc"
+#     timeout: 60
+#     force: true
+#     force_basic_auth: "{{ caddy_license != 'personal' }}"
+#   when: caddy_pgp_verify_signatures and (caddy_binary_cache.changed or caddy_download.changed)
+#   tags: skip_ansible_lint
 
-- name: Verify Caddy signature
-  command: >
-    gpg
-      --verify {{ caddy_home }}/caddy.tar.gz.asc
-      {{ caddy_home }}/caddy.tar.gz
-  when: caddy_pgp_verify_signatures and (caddy_binary_cache.changed or caddy_download.changed)
-  tags: skip_ansible_lint
-
-- name: Extract Caddy
-  unarchive:
-    src: "{{ caddy_home }}/caddy.tar.gz"
-    dest: "{{ caddy_home }}"
-    copy: false
-    owner: "{{ caddy_user }}"
-  when: caddy_binary_cache.changed
-  tags: skip_ansible_lint
-
-- name: Extract Caddy
-  unarchive:
-    src: "{{ caddy_home }}/caddy.tar.gz"
-    dest: "{{ caddy_home }}"
-    creates: "{{ caddy_home }}/caddy"
-    copy: false
-    owner: "{{ caddy_user }}"
+# - name: Verify Caddy signature
+#   command: >
+#     gpg
+#       --verify {{ caddy_home }}/caddy.tar.gz.asc
+#       {{ caddy_home }}/caddy.tar.gz
+#   when: caddy_pgp_verify_signatures and (caddy_binary_cache.changed or caddy_download.changed)
+#   tags: skip_ansible_lint
 
 - name: Determine Caddy binary path
   set_fact:
@@ -134,11 +123,12 @@
 
 - name: Copy Caddy Binary
   copy:
-    src: "{{ caddy_home }}/caddy"
+    src: "{{ caddy_home }}/{{ caddy_bin_name }}"
     dest: "{{ caddy_bin }}"
     mode: 0755
     remote_src: true
-  notify: restart caddy
+  notify:
+    - Restart caddy
 
 - name: Create directories
   file:
@@ -162,7 +152,8 @@
     content: "{{ caddy_config }}"
     dest: "{{ caddy_conf_dir }}/Caddyfile"
     owner: "{{ caddy_user }}"
-  notify: reload caddy
+  notify:
+    - Reload caddy
 
 - name: Systemd service
   template:
@@ -171,14 +162,18 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart caddy
+  notify:
+    - Restart caddy
 
 - name: Set capability on the binary file to be able to bind to TCP port <1024
   capabilities:
     path: "{{ caddy_bin }}"
-    capability: cap_net_bind_service+ep
+    capability: cap_net_bind_service+eip
     state: present
   when: caddy_setcap
+
+- name: Ensue caddy service is up-to-date before starting it
+  meta: flush_handlers
 
 - name: Start Caddy service
   systemd:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Build headers to use when making requests to github
   set_fact:
-    caddy_github_headers: "{{ caddy_github_headers | combine({'Authorisation': 'token ' + caddy_github_token}) }}"
+    caddy_github_headers: "{{ caddy_github_headers | combine({'Authorization': 'token ' + caddy_github_token}) }}"
   when: caddy_github_token | length > 0
 
 - name: Get all Caddy releases

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,10 +33,13 @@
   when: caddy_update
   register: caddy_features_cache
 
+- include: github-url.yml
+  when: caddy_use_github
+
 - name: Download Caddy
   get_url:
     url: "{{ caddy_url }}"
-    dest: "{{ caddy_home }}/caddy"
+    dest: "{{ caddy_home }}/{{ 'caddy.tar.gz' if caddy_use_github else 'caddy' }}"
     force: true
     timeout: 300
   retries: 3
@@ -48,12 +51,15 @@
 - name: Download Caddy
   get_url:
     url: "{{ caddy_url }}"
-    dest: "{{ caddy_home }}/caddy"
+    dest: "{{ caddy_home }}/{{ 'caddy.tar.gz' if caddy_use_github else 'caddy' }}"
     timeout: 300
   retries: 3
   delay: 2
   register: caddy_download
   tags: skip_ansible_lint
+
+- include: github-extract.yml
+  when: caddy_use_github
 
 - name: Determine Caddy binary path
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
   copy:
     content: "{{ ','.join(caddy_packages) }}"
     dest: "{{ caddy_home }}/features.txt"
+    mode: 0640
   when: caddy_update
   register: caddy_features_cache
 
@@ -131,6 +132,7 @@
     content: "{{ caddy_config }}"
     dest: "{{ caddy_conf_dir }}/Caddyfile"
     owner: "{{ caddy_user }}"
+    mode: 0640
   notify:
     - Reload caddy
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,45 +55,6 @@
   register: caddy_download
   tags: skip_ansible_lint
 
-- name: Check if Caddy PGP key is already in keyring
-  command: gpg --list-keys {{ caddy_pgp_key_id }}
-  changed_when: gpg_list_keys is failed
-  register: gpg_list_keys
-  when: caddy_pgp_verify_signatures
-  tags: skip_ansible_lint
-  failed_when:
-    - "gpg_list_keys is failed"
-    - "'gpg: error reading key: No public key' not in gpg_list_keys.stderr"
-    - "'gpg: error reading key: public key not found' not in gpg_list_keys.stderr"
-
-- name: Download Caddy PGP key
-  command: >
-    gpg
-      --keyserver-options timeout={{ caddy_pgp_recv_timeout }}
-      --keyserver {{ caddy_pgp_key_server }}
-      --recv-keys {{ caddy_pgp_key_id }}
-  when: caddy_pgp_verify_signatures and gpg_list_keys.changed
-  register: caddy_pgp_key
-  changed_when: '"imported" in caddy_pgp_key.stdout'
-  tags: skip_ansible_lint
-
-# - name: Download Caddy signature
-#   get_url:
-#     url: "{{ caddy_sig_url }}"
-#     dest: "{{ caddy_home }}/caddy.tar.gz.asc"
-#     timeout: 60
-#     force: true
-#   when: caddy_pgp_verify_signatures and (caddy_binary_cache.changed or caddy_download.changed)
-#   tags: skip_ansible_lint
-
-# - name: Verify Caddy signature
-#   command: >
-#     gpg
-#       --verify {{ caddy_home }}/caddy.tar.gz.asc
-#       {{ caddy_home }}/caddy.tar.gz
-#   when: caddy_pgp_verify_signatures and (caddy_binary_cache.changed or caddy_download.changed)
-#   tags: skip_ansible_lint
-
 - name: Determine Caddy binary path
   set_fact:
     caddy_bin: "{{ caddy_bin_dir }}/caddy"
@@ -133,7 +94,7 @@
   notify:
     - Reload caddy
 
-- name: Systemd service
+- name: Template systemd service
   template:
     src: caddy.service
     dest: /etc/systemd/system/caddy.service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,6 @@
   get_url:
     url: "{{ caddy_url }}"
     dest: "{{ caddy_home }}/caddy"
-    force_basic_auth: "{{ caddy_license != 'personal' }}"
     force: true
     timeout: 300
   retries: 3
@@ -50,7 +49,6 @@
   get_url:
     url: "{{ caddy_url }}"
     dest: "{{ caddy_home }}/caddy"
-    force_basic_auth: "{{ caddy_license != 'personal' }}"
     timeout: 300
   retries: 3
   delay: 2
@@ -85,7 +83,6 @@
 #     dest: "{{ caddy_home }}/caddy.tar.gz.asc"
 #     timeout: 60
 #     force: true
-#     force_basic_auth: "{{ caddy_license != 'personal' }}"
 #   when: caddy_pgp_verify_signatures and (caddy_binary_cache.changed or caddy_download.changed)
 #   tags: skip_ansible_lint
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
     system: true
     createhome: true
     home: "{{ caddy_home }}"
+  register: caddy_user_details
 
 - name: Build headers to use when making requests to github
   set_fact:
@@ -20,6 +21,8 @@
     dest: "{{ caddy_home }}/releases.txt"
     force: true
     headers: '{{ caddy_github_headers }}'
+    owner: "{{ caddy_user }}"
+    group: "{{ caddy_user_details.group }}"
   retries: 3
   delay: 2
   when: caddy_update
@@ -30,6 +33,8 @@
     content: "{{ ','.join(caddy_packages) }}"
     dest: "{{ caddy_home }}/features.txt"
     mode: 0640
+    owner: "{{ caddy_user }}"
+    group: "{{ caddy_user_details.group }}"
   when: caddy_update
   register: caddy_features_cache
 
@@ -42,6 +47,9 @@
     dest: "{{ caddy_home }}/{{ 'caddy.tar.gz' if caddy_use_github else 'caddy' }}"
     force: true
     timeout: 300
+    mode: 0644
+    owner: "{{ caddy_user }}"
+    group: "{{ caddy_user_details.group }}"
   retries: 3
   delay: 2
   when: caddy_releases_cache.changed or caddy_features_cache.changed
@@ -53,6 +61,9 @@
     url: "{{ caddy_url }}"
     dest: "{{ caddy_home }}/{{ 'caddy.tar.gz' if caddy_use_github else 'caddy' }}"
     timeout: 300
+    mode: 0644
+    owner: "{{ caddy_user }}"
+    group: "{{ caddy_user_details.group }}"
   retries: 3
   delay: 2
   register: caddy_download
@@ -60,10 +71,6 @@
 
 - include: github-extract.yml
   when: caddy_use_github
-
-- name: Determine Caddy binary path
-  set_fact:
-    caddy_bin: "{{ caddy_bin_dir }}/caddy"
 
 - name: Copy Caddy Binary
   copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,14 +32,10 @@
   when: caddy_update
   register: caddy_features_cache
 
-- name: Set some common parameters
-  set_fact:
-    caddy_bin_name: "caddy_{{ caddy_os }}_{{ go_arch }}"
-
 - name: Download Caddy
   get_url:
     url: "{{ caddy_url }}"
-    dest: "{{ caddy_home }}/{{ caddy_bin_name }}"
+    dest: "{{ caddy_home }}/caddy"
     force_basic_auth: "{{ caddy_license != 'personal' }}"
     force: true
     timeout: 300
@@ -52,7 +48,7 @@
 - name: Download Caddy
   get_url:
     url: "{{ caddy_url }}"
-    dest: "{{ caddy_home }}/{{ caddy_bin_name }}"
+    dest: "{{ caddy_home }}/caddy"
     force_basic_auth: "{{ caddy_license != 'personal' }}"
     timeout: 300
   retries: 3
@@ -106,7 +102,7 @@
 
 - name: Copy Caddy Binary
   copy:
-    src: "{{ caddy_home }}/{{ caddy_bin_name }}"
+    src: "{{ caddy_home }}/caddy"
     dest: "{{ caddy_bin }}"
     mode: 0755
     remote_src: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,9 @@
   set_fact:
     caddy_bin_name: "caddy_{{ caddy_os }}_{{ go_arch }}"
     caddy_common_args: "os={{ caddy_os }}&arch={{ go_arch }}&license={{ caddy_license }}\
-                        {% for pkg in caddy_packages %}{% if loop.first %}&{% endif %}p={{ pkg }}{% if not loop.last %},{% endif %}{% endfor %}"
+                        {% for pkg in caddy_packages %}\
+                        {% if loop.first %}&{% endif %}p={{ pkg }}{% if not loop.last %},{% endif %}\
+                        {% endfor %}"
 
 - name: Build base URL
   set_fact:

--- a/tasks/packages-apt.yml
+++ b/tasks/packages-apt.yml
@@ -5,12 +5,6 @@
     update_cache: true
     cache_valid_time: 43200   # 12 hours
 
-- name: Install git
-  apt:
-    name: git
-    state: present
-  when: caddy_features is search('git')
-
 # This is required because it provides the /bin/kill binary used in the service file
 - name: Install procps
   apt:

--- a/tasks/packages-dnf.yml
+++ b/tasks/packages-dnf.yml
@@ -1,7 +1,1 @@
 ---
-
-- name: Install git
-  dnf:
-    name: git
-    state: present
-  when: caddy_features is search('git')

--- a/tasks/packages-pacman.yml
+++ b/tasks/packages-pacman.yml
@@ -1,7 +1,1 @@
 ---
-
-- name: Install git
-  pacman:
-    name: git
-    state: present
-  when: caddy_features is search('git')

--- a/tasks/packages-yum.yml
+++ b/tasks/packages-yum.yml
@@ -1,7 +1,1 @@
 ---
-
-- name: Install git
-  yum:
-    name: git
-    state: present
-  when: caddy_features is search('git')

--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -29,7 +29,7 @@ Group={{ caddy_user }}
 ; Letsencrypt-issued certificates will be written to this directory.
 Environment=CADDYPATH={{ caddy_certs_dir }}
 
-ExecStart="{{ caddy_bin_dir }}/caddy" run --environ --config "{{ caddy_conf_dir }}/Caddyfile"
+ExecStart="{{ caddy_bin_dir }}/caddy" run --environ --config "{{ caddy_conf_dir }}/Caddyfile" {{ caddy_additional_args }}
 ExecReload="{{ caddy_bin_dir }}/caddy" reload --config "{{ caddy_conf_dir }}/Caddyfile"
 
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.

--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -29,10 +29,8 @@ Group={{ caddy_user }}
 ; Letsencrypt-issued certificates will be written to this directory.
 Environment=CADDYPATH={{ caddy_certs_dir }}
 
-
-; Always set "-root" to something safe in case it gets forgotten in the Caddyfile.
-ExecStart={{ caddy_bin_dir }}/caddy -log {{ caddy_log_file }} -http2={{ caddy_http2_enabled }} -agree=true -conf={{ caddy_conf_dir }}/Caddyfile -root=/var/tmp {{ caddy_additional_args }}
-ExecReload=/bin/kill -USR1 $MAINPID
+ExecStart="{{ caddy_bin_dir }}/caddy" run --environ --config "{{ caddy_conf_dir }}/Caddyfile"
+ExecReload="{{ caddy_bin_dir }}/caddy" reload --config "{{ caddy_conf_dir }}/Caddyfile"
 
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.
 LimitNOFILE=1048576

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,7 @@
 ---
 # vars file for caddy-ansible
+caddy_github_headers: {}
+
 go_arch_map:
   i386: '386'
   x86_64: 'amd64'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,3 +12,11 @@ go_arch_map:
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 
 caddy_auth_info: "{{ caddy_license_account_id }}:{{ caddy_license_api_key }}"
+
+caddy_url_base: "https://{{ caddy_auth_info + ' ' if caddy_license != 'personal' else '' }}caddyserver.com/api/download"
+caddy_url_args: "os={{ caddy_os }}&arch={{ go_arch }}&license={{ caddy_license }}\
+                 {% for pkg in caddy_packages %}\
+                 {% if loop.first %}&{% endif %}p={{ pkg }}{% if not loop.last %},{% endif %}\
+                 {% endfor %}"
+caddy_url: "{{ caddy_url_base }}?{{ caddy_url_args }}"
+caddy_sig_url: "{{ caddy_url_base }}/signature?{{ caddy_url_args }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,6 +11,8 @@ go_arch_map:
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 
+caddy_bin: "{{ caddy_bin_dir }}/caddy"
+
 caddy_url: "https://caddyserver.com/api/download?os={{ caddy_os }}&arch={{ go_arch }}\
            {% for pkg in caddy_packages %}\
            {% if loop.first %}&{% endif %}p={{ pkg | urlencode() }}{% if not loop.last %},{% endif %}\

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,10 +11,9 @@ go_arch_map:
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 
-caddy_url_base: "https://caddyserver.com/api/download"
-caddy_url_args: "os={{ caddy_os }}&arch={{ go_arch }}\
-                 {% for pkg in caddy_packages %}\
-                 {% if loop.first %}&{% endif %}p={{ pkg }}{% if not loop.last %},{% endif %}\
-                 {% endfor %}"
-caddy_url: "{{ caddy_url_base }}?{{ caddy_url_args }}"
-caddy_sig_url: "{{ caddy_url_base }}/signature?{{ caddy_url_args }}"
+caddy_url: "https://caddyserver.com/api/download?os={{ caddy_os }}&arch={{ go_arch }}\
+           {% for pkg in caddy_packages %}\
+           {% if loop.first %}&{% endif %}p={{ pkg | urlencode() }}{% if not loop.last %},{% endif %}\
+           {% endfor %}"
+
+caddy_use_github: "{{ caddy_packages == [] }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,10 +11,8 @@ go_arch_map:
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 
-caddy_auth_info: "{{ caddy_license_account_id }}:{{ caddy_license_api_key }}"
-
-caddy_url_base: "https://{{ caddy_auth_info + ' ' if caddy_license != 'personal' else '' }}caddyserver.com/api/download"
-caddy_url_args: "os={{ caddy_os }}&arch={{ go_arch }}&license={{ caddy_license }}\
+caddy_url_base: "https://caddyserver.com/api/download"
+caddy_url_args: "os={{ caddy_os }}&arch={{ go_arch }}\
                  {% for pkg in caddy_packages %}\
                  {% if loop.first %}&{% endif %}p={{ pkg }}{% if not loop.last %},{% endif %}\
                  {% endfor %}"


### PR DESCRIPTION
Main changes in addition to the support for the new caddy version:

- When downloading with no additional packages requested the version from github will be downloaded.
- Added support for providing a token to github. This means you can have a higher rate limit for API requests. This is not provided on the download requests because it is not needed and breaks things.
- Remove license support - caddy no longer provides commercial licensing so this is not supported on their end any more.
- Remove PGP verification. I created an issue (https://github.com/caddy-ansible/caddy-ansible/issues/8) to track this because I would like to add this back one day but currently there are no signatures provided. We could consider having an issue to check the hashes but that doesn't have the same value.
- Update README formatting and add a table of contents. This was generated using `markdown-toc -i README.md` but could also be manually maintained.