### PR TITLE
Adapt arch mapping to caddy v2

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,8 +6,8 @@ go_arch_map:
   i386: '386'
   x86_64: 'amd64'
   aarch64: 'arm64'
-  armv7l: 'arm7'
-  armv6l: 'arm6'
+  armv7l: 'armv7'
+  armv6l: 'armv6'
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 


### PR DESCRIPTION
Since caddy v2 the `arm6` and `arm7` architectures are called `armv6` and `armv7` in the release download files.