### PR TITLE
Install the separate molecule docker module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - MOLECULE_DISTRO: debian9
     - MOLECULE_DISTRO: debian10
 install:
-  - pip install ansible molecule yamllint ansible-lint docker pytest testinfra
+  - pip install ansible molecule molecule-docker yamllint ansible-lint docker pytest testinfra
 script:
   - molecule test
 notifications:


### PR DESCRIPTION
See https://github.com/ansible-community/molecule/issues/2891 for more information on the driver being split out.

Add the new python module required for molecule docker tests.