### PR TITLE
Use correct arch parameters for arm devices

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,2 @@
 skip_list:
-  - '106'  # Role name caddy-ansible does not match `^[a-z][a-z0-9_]+$` pattern
+  - 'role-name'     # Role name caddy-ansible does not match `^[a-z][a-z0-9_]+$` pattern

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ caddy_github_token: ""
 - hosts: all
   become: yes
   roles:
-    - role: caddy
+    - role: caddy_ansible.caddy_ansible
       caddy_config: |
         files.example.com
         encode gzip
@@ -167,7 +167,7 @@ Example with DigitalOcean DNS for TLS:
 ---
 - hosts: all
   roles:
-    - role: caddy-ansible
+    - role: caddy_ansible.caddy_ansible
       caddy_environment_variables:
         DO_AUTH_TOKEN: "your-token-here"
       caddy_systemd_capabilities_enabled: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   author: caddy_ansible
+  role_name: caddy_ansible
   description: Installs and configures a Caddy webserver
   license: MIT
   min_ansible_version: 2.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  author: antoiner77
+  author: caddy_ansible
   description: Installs and configures a Caddy webserver
   license: MIT
   min_ansible_version: 2.0

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   roles:
-    - role: caddy-ansible
+    - role: caddy_ansible.caddy_ansible
   tasks:
     - name: Ensure ss is installed (for testinfra)
       yum:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -19,6 +19,8 @@ provisioner:
   name: ansible
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+  env:
+    ANSIBLE_ROLES_PATH: "../../.cache/roles"
 scenario:
   name: default
 verifier:

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -5,4 +5,4 @@
     - name: Install curl
       package: name=curl state=present
   roles:
-    - caddy-ansible
+    - caddy_ansible.caddy_ansible

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,7 +13,13 @@ go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }
 
 caddy_bin: "{{ caddy_bin_dir }}/caddy"
 
-caddy_url: "https://caddyserver.com/api/download?os={{ caddy_os }}&arch={{ go_arch }}\
+caddy_arch_param_map:
+  armv7l: 'arch=arm&arm=7'
+  armv6l: 'arch=arm&arm=6'
+
+caddy_arch_param: "{{ caddy_arch_param_map[ansible_architecture] | default('arch={{ go_arch }}') }}"
+
+caddy_url: "https://caddyserver.com/api/download?os={{ caddy_os }}&{{ caddy_arch_param }}\
            {% for pkg in caddy_packages %}\
            {% if loop.first %}&{% endif %}p={{ pkg | urlencode() }}{% if not loop.last %},{% endif %}\
            {% endfor %}"


### PR DESCRIPTION
Without this change I was not able to run this playbook against a Raspberry Pi when including any plugins. With the change it worked & I was able to set caddy up as required.

I thought about trying to cover all possibilities but just handling the
same things as `go_arch_map` seemed reasonable here.

Closes #12 