### PR TITLE
add caddy_conf_filename variable to support json format

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,3 @@
+---
 skip_list:
   - 'role-name'     # Role name caddy-ansible does not match `^[a-z][a-z0-9_]+$` pattern

--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ None
 
 ### The Caddyfile
 
-See [Caddyfile docs](https://caddyserver.com/docs/caddyfile). Notice the `|` used to include a multi-line string.
+See [Caddyfile docs](https://caddyserver.com/docs/caddyfile). Notice the `|` used to include a multi-line string. You may set `caddy_conf_filename` to `config.json` to use json format.
 
 default:
 
 ```yaml
+caddy_conf_filename: Caddyfile
 caddy_config: |
   http://localhost:2020
   respond "Hello, world!"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,6 @@ caddy_github_token: ""
 caddy_log_dir: /var/log/caddy
 caddy_log_file: stdout
 caddy_certs_dir: /etc/ssl/caddy
-caddy_http2_enabled: "true"
 # additional cli args to pass to caddy
 caddy_additional_args: ""
 caddy_systemd_network_dependency: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ caddy_packages: []
 caddy_update: true
 caddy_bin_dir: /usr/local/bin
 caddy_conf_dir: /etc/caddy
+caddy_conf_filename: Caddyfile
 caddy_github_token: ""
 caddy_log_dir: /var/log/caddy
 caddy_log_file: stdout

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,10 +100,10 @@
     owner: "{{ caddy_user }}"
     mode: 0775
 
-- name: Create Caddyfile
+- name: Create caddy config
   copy:
     content: "{{ caddy_config }}"
-    dest: "{{ caddy_conf_dir }}/Caddyfile"
+    dest: "{{ caddy_conf_dir }}/{{ caddy_conf_filename }}"
     owner: "{{ caddy_user }}"
     mode: 0640
   notify:

--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -29,8 +29,8 @@ Group={{ caddy_user }}
 ; Letsencrypt-issued certificates will be written to this directory.
 Environment=CADDYPATH={{ caddy_certs_dir }}
 
-ExecStart="{{ caddy_bin_dir }}/caddy" run --environ --config "{{ caddy_conf_dir }}/Caddyfile" {{ caddy_additional_args }}
-ExecReload="{{ caddy_bin_dir }}/caddy" reload --config "{{ caddy_conf_dir }}/Caddyfile"
+ExecStart="{{ caddy_bin_dir }}/caddy" run --environ --config "{{ caddy_conf_dir }}/{{ caddy_conf_filename }}" {{ caddy_additional_args }}
+ExecReload="{{ caddy_bin_dir }}/caddy" reload --config "{{ caddy_conf_dir }}/{{ caddy_conf_filename }}"
 
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.
 LimitNOFILE=1048576


### PR DESCRIPTION
If `--config` arg ends with `Caddyfile`, specifying `--adpater json` won't force caddy to treat it as json. Therefore I add `caddy_conf_filename` to control config format (only caddyfile and json seem to be supported now).