### PR TITLE
Fix checksum-forced downloading

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
 - name: Download Caddy
   get_url:
     url: "{{ caddy_url }}"
-    checksum: "{{ caddy_checksum_url | default(omit) }}"
+    checksum: "{{ caddy_checksum_url | default('') }}"
     dest: "{{ caddy_home }}/{{ 'caddy.tar.gz' if caddy_use_github else 'caddy' }}"
     force: true
     timeout: 300
@@ -60,7 +60,7 @@
 - name: Download Caddy
   get_url:
     url: "{{ caddy_url }}"
-    checksum: "{{ caddy_checksum_url | default(omit) }}"
+    checksum: "{{ caddy_checksum_url | default('') }}"
     dest: "{{ caddy_home }}/{{ 'caddy.tar.gz' if caddy_use_github else 'caddy' }}"
     timeout: 300
     mode: 0644


### PR DESCRIPTION
Rebased on #24
caddy was downloaded once even when `caddy_update` is `false`, probably because `omit` does not make `checksum` undefined or empty, forcing downloading and checksum computation.

See https://github.com/ansible/ansible/issues/44261. debug prints `{{ undefined_var | default(omit) }}` as "Hello World!". It should have been simply `default('')`.
https://github.com/caddy-ansible/caddy-ansible/blob/c9b442887f7c7047d3f225dacae91ee3835fc56b/tasks/main.yml#L59-L73
