### PR TITLE
Detect systemd version

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -14,4 +14,4 @@
 
 - name: Set systemd version fact
   set_fact:
-    caddy_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+    caddy_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[1] }}"


### PR DESCRIPTION
A patch for #29

Before on ubuntu 20.04
```
(245.4-4ubuntu3.4)
```
After
```
245
```

Before on centos 8
```
(239-41.el8_3.1)
```
After
```
239
```