### PR TITLE
Fix systemd service templating

### DIFF
--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -29,8 +29,8 @@ Group={{ caddy_user }}
 ; Letsencrypt-issued certificates will be written to this directory.
 Environment=CADDYPATH={{ caddy_certs_dir }}
 
-ExecStart="{{ caddy_bin_dir }}/caddy" run --environ --config "{{ caddy_conf_dir }}/{{ caddy_conf_filename }}" {{ caddy_additional_args }}
-ExecReload="{{ caddy_bin_dir }}/caddy" reload --config "{{ caddy_conf_dir }}/{{ caddy_conf_filename }}"
+ExecStart="{{ caddy_bin_dir }}/caddy run --environ --config {{ caddy_conf_dir }}/{{ caddy_conf_filename }} {{ caddy_additional_args }}"
+ExecReload="{{ caddy_bin_dir }}/caddy reload --force --config "{{ caddy_conf_dir }}/{{ caddy_conf_filename }}"
 
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.
 LimitNOFILE=1048576


### PR DESCRIPTION
- The ExecStart and ExecReload commands end up malformed due to incorrect templating (`ExecStart="/usr/local/bin/caddy" run --environ --config ...`) which makes them fail
- The `--force` flag is included in the [reference service file](https://github.com/caddyserver/dist/blob/master/init/caddy.service)