### PR TITLE
Allow setting the server to download caddy from

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,5 @@ caddy_config: |
 caddy_environment_variables: {}
 caddy_environment_files: []
 caddy_os: linux
+caddy_url_base: "https://caddyserver.com/api/download"
+caddy_download_timeout: 300

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,7 +48,7 @@
     checksum: "{{ caddy_checksum_url | default(omit) }}"
     dest: "{{ caddy_home }}/{{ 'caddy.tar.gz' if caddy_use_github else 'caddy' }}"
     force: true
-    timeout: 300
+    timeout: "{{ caddy_download_timeout }}"
     mode: 0644
     owner: "{{ caddy_user }}"
     group: "{{ caddy_user_details.group }}"
@@ -63,7 +63,7 @@
     url: "{{ caddy_url }}"
     checksum: "{{ caddy_checksum_url | default(omit) }}"
     dest: "{{ caddy_home }}/{{ 'caddy.tar.gz' if caddy_use_github else 'caddy' }}"
-    timeout: 300
+    timeout: "{{ caddy_download_timeout }}"
     mode: 0644
     owner: "{{ caddy_user }}"
     group: "{{ caddy_user_details.group }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,7 +19,7 @@ caddy_arch_param_map:
 
 caddy_arch_param: "{{ caddy_arch_param_map[ansible_architecture] | default('arch=' + go_arch) }}"
 
-caddy_url: "https://caddyserver.com/api/download?os={{ caddy_os }}&{{ caddy_arch_param }}\
+caddy_url: "{{ caddy_url_base }}?os={{ caddy_os }}&{{ caddy_arch_param }}\
            {% for pkg in caddy_packages %}\
            &p={{ pkg | urlencode() }}\
            {% endfor %}"


### PR DESCRIPTION
This is one of the things which enables us to give people a sensible way to avoid hitting the caddy build server if they are using plugins (as discussed in previous issues).