### PR TITLE
ADD tasks/packages-zypper.yml

### DIFF
--- a/tasks/packages-zypper.yml
+++ b/tasks/packages-zypper.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Install libcap-progs
+  community.general.zypper:
+    name: libcap-progs
+    state: present
+  when: caddy_setcap


### PR DESCRIPTION
New file `tasks/packages-zypper.yml` used on SUSE/openSUSE.

With this file the role worked in my tests, but only with ports > 1024. Not sure what is missing.

The caddy package delivered by openSUSE works fine.