### PR TITLE
ss installation optimization

### DIFF
--- a/molecule/default/converge-version.yml
+++ b/molecule/default/converge-version.yml
@@ -6,12 +6,6 @@
       caddy_version: '2.7.6'
   tasks:
     - name: Ensure ss is installed (for testinfra)
-      ansible.builtin.yum:
-        name: iproute
-        state: present
-      when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux', 'Fedora']
-    - name: Ensure ss is installed (for testinfra)
       ansible.builtin.package:
-        name: iproute2
+        name: "iproute{{ '2' if ansible_os_family == 'Debian' }}"
         state: present
-      when: ansible_distribution not in ['CentOS', 'Red Hat Enterprise Linux', 'Fedora']

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,12 +5,6 @@
     - role: caddy_ansible.caddy_ansible
   tasks:
     - name: Ensure ss is installed (for testinfra)
-      ansible.builtin.yum:
-        name: iproute
-        state: present
-      when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux', 'Fedora']
-    - name: Ensure ss is installed (for testinfra)
       ansible.builtin.package:
-        name: iproute2
+        name: "iproute{{ '2' if ansible_os_family == 'Debian' }}"
         state: present
-      when: ansible_distribution not in ['CentOS', 'Red Hat Enterprise Linux', 'Fedora']


### PR DESCRIPTION
If `MOLECULE_DISTRO=(almalinux|rockylinux)8` the task fails because the name is not included in the RedHat list. 

It is better to focus on ansible_os_family.