### PR TITLE
add jmespath dep note

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This role installs and configures the caddy web server. The user can specify any
 
 ## Dependencies
 
-None
+`jmespath`, which must be manually installed on the Ansible controller. See [Selecting JSON data: JSON queries](https://docs.ansible.com/ansible/latest/collections/community/general/docsite/filter_guide_selecting_json_data.html) for more details.
 
 ## Role Variables
 


### PR DESCRIPTION
Hello! Just a friendly docs PR, informing new users about the need for jmespath. 

Without jmespath installed, I saw the following error. 

```
TASK [caddy_ansible.caddy_ansible : Set variable with list of available releases] *********************************************************************************************************************************
fatal: [lb-0]: FAILED! => {"msg": "You need to install \"jmespath\" prior to running json_query filter"}
```

I'm enjoying caddy-ansible. Thank you!