### PR TITLE
feat: Include xcaddy build option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,3 +36,7 @@ caddy_update: true
 caddy_url_base: "https://caddyserver.com/api/download"
 caddy_user: www-data
 caddy_version: ''
+
+caddy_build: false
+xcaddy_version: '0.4.4'
+xcaddy_url_base: "https://github.com/caddyserver/xcaddy/releases/download"

--- a/tasks/github-xcaddy.yml
+++ b/tasks/github-xcaddy.yml
@@ -1,0 +1,43 @@
+
+- name: Download xcaddy
+  ansible.builtin.get_url:
+    url: "{{ xcaddy_url_base }}/v{{ xcaddy_version }}/xcaddy_{{ xcaddy_version}}_{{ caddy_os}}_{{ go_arch }}.tar.gz"
+    dest: "{{ caddy_home }}/{{ 'xcaddy.tar.gz' }}"
+    force: true
+    timeout: "{{ caddy_download_timeout }}"
+    mode: 0644
+    owner: "{{ caddy_user }}"
+    group: "{{ caddy_user_details.group }}"
+  retries: 3
+  delay: 2
+  # when: "caddy_releases_cache.changed or caddy_features_cache.changed or caddy_version_cache.changed"
+  register: xcaddy_binary_cache
+  tags: skip_ansible_lint
+
+- name: Extract xcaddy
+  ansible.builtin.unarchive:
+    src: "{{ caddy_home }}/xcaddy.tar.gz"
+    dest: "{{ caddy_home }}"
+    copy: false
+    mode: 0644
+    owner: "{{ caddy_user }}"
+    group: "{{ caddy_user_details.group }}"
+  when: xcaddy_binary_cache.changed
+  tags: skip_ansible_lint
+
+- name: Extract xcaddy
+  ansible.builtin.unarchive:
+    src: "{{ caddy_home }}/xcaddy.tar.gz"
+    dest: "{{ caddy_home }}"
+    creates: "{{ caddy_home }}/xcaddy"
+    copy: false
+    mode: 0644
+    owner: "{{ caddy_user }}"
+    group: "{{ caddy_user_details.group }}"
+
+- name: Copy xcaddy Binary
+  ansible.builtin.copy:
+    src: "{{ caddy_home }}/xcaddy"
+    dest: "{{ caddy_bin_dir }}/xcaddy"
+    mode: 0755
+    remote_src: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,39 +73,64 @@
   when: (caddy_update or not caddy_version_file.stat.exists)
   register: caddy_version_cache
 
-- name: Download Caddy
-  ansible.builtin.get_url:
-    url: "{{ caddy_url }}"
-    checksum: "{{ caddy_checksum_url | default(omit) }}"
-    dest: "{{ caddy_home }}/{{ 'caddy.tar.gz' if caddy_use_github else 'caddy' }}"
-    force: true
-    timeout: "{{ caddy_download_timeout }}"
-    mode: 0644
-    owner: "{{ caddy_user }}"
-    group: "{{ caddy_user_details.group }}"
-  retries: 3
-  delay: 2
-  when: "caddy_releases_cache.changed or caddy_features_cache.changed or caddy_version_cache.changed"
-  register: caddy_binary_cache
-  tags: skip_ansible_lint
+- name: Build Caddy with xCaddy
+  block:
 
-- name: Download Caddy
-  ansible.builtin.get_url:
-    url: "{{ caddy_url }}"
-    checksum: "{{ caddy_checksum_url | default(omit) }}"
-    dest: "{{ caddy_home }}/{{ 'caddy.tar.gz' if caddy_use_github else 'caddy' }}"
-    timeout: "{{ caddy_download_timeout }}"
-    mode: 0644
-    owner: "{{ caddy_user }}"
-    group: "{{ caddy_user_details.group }}"
-  retries: 3
-  delay: 2
-  register: caddy_download
-  tags: skip_ansible_lint
+    - name: Check if xcaddy already exists
+      ansible.builtin.stat:
+        path: "{{ caddy_bin_dir }}/xcaddy"
+      register: xcaddy_bin
 
-- name: Include tasks to extract files if downloading from github
-  ansible.builtin.include_tasks: github-extract.yml
-  when: caddy_use_github
+    - name: Download xcaddy
+      ansible.builtin.include_tasks: github-xcaddy.yml
+      when: not xcaddy_bin.stat.exists
+
+    - name: Build caddy
+      ansible.builtin.command:
+        cmd: "{{ caddy_bin_dir }}/xcaddy build --with {{ caddy_packages | join(' --with ') }}"
+      args:
+        chdir: "{{ caddy_home }}"
+
+  when: caddy_build
+
+- name: Download pre-built Caddy
+  block:
+
+    - name: Download Caddy
+      ansible.builtin.get_url:
+        url: "{{ caddy_url }}"
+        checksum: "{{ caddy_checksum_url | default(omit) }}"
+        dest: "{{ caddy_home }}/{{ 'caddy.tar.gz' if caddy_use_github else 'caddy' }}"
+        force: true
+        timeout: "{{ caddy_download_timeout }}"
+        mode: 0644
+        owner: "{{ caddy_user }}"
+        group: "{{ caddy_user_details.group }}"
+      retries: 3
+      delay: 2
+      when: "caddy_releases_cache.changed or caddy_features_cache.changed or caddy_version_cache.changed"
+      register: caddy_binary_cache
+      tags: skip_ansible_lint
+
+    - name: Download Caddy
+      ansible.builtin.get_url:
+        url: "{{ caddy_url }}"
+        checksum: "{{ caddy_checksum_url | default(omit) }}"
+        dest: "{{ caddy_home }}/{{ 'caddy.tar.gz' if caddy_use_github else 'caddy' }}"
+        timeout: "{{ caddy_download_timeout }}"
+        mode: 0644
+        owner: "{{ caddy_user }}"
+        group: "{{ caddy_user_details.group }}"
+      retries: 3
+      delay: 2
+      register: caddy_download
+      tags: skip_ansible_lint
+
+    - name: Include tasks to extract files if downloading from github
+      ansible.builtin.include_tasks: github-extract.yml
+      when: caddy_use_github
+
+  when: not caddy_build
 
 - name: Copy Caddy Binary
   ansible.builtin.copy:

--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -32,6 +32,10 @@ Environment=CADDYPATH={{ caddy_certs_dir }}
 ExecStart="{{ caddy_bin_dir }}/caddy" run --environ --config "{{ caddy_conf_dir }}/{{ caddy_conf_filename }}" {{ caddy_additional_args }}
 ExecReload="{{ caddy_bin_dir }}/caddy" reload --config "{{ caddy_conf_dir }}/{{ caddy_conf_filename }}"
 
+{% if caddy_setcap %}
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+{% endif %}
+
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.
 LimitNOFILE=1048576
 {% if caddy_systemd_nproc_limit > 0 %}


### PR DESCRIPTION
I was having issues getting the caddyserver website to build with the addons I needed, so I had to use xcaddy instead. I've added this as an option ('caddy_build') that defaults to 'false' (so, shouldn't change default behaviour).

This also fixes an issue I was having (possibly only because of the xcaddy build?) that caddy wasn't able to bind to 80/443. I've added 'AmbientCapabilities=CAP_NET_BIND_SERVICE' into the service config as well, which fixed the issue for me.

This could possibly do with some cleanup/additions, but it works. The version of xcaddy defaults to 0.4.4, and needs to be manually updated by the user, and the role requires the right version of golang to be pre-installed (I'm working on a separate role for that).