### PR TITLE
Add validation of config file when copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ caddy_github_token: ""
   become: yes
   roles:
     - role: caddy_ansible.caddy_ansible
+      caddy_additional_args: "--adapter caddyfile"
       caddy_config: |
         files.example.com
         encode gzip
@@ -217,9 +218,9 @@ Example with DigitalOcean DNS for TLS:
 - hosts: all
   roles:
     - role: caddy_ansible.caddy_ansible
+      caddy_additional_args: "--adapter caddyfile"
       caddy_environment_variables:
         DO_AUTH_TOKEN: "your-token-here"
-      caddy_systemd_capabilities_enabled: true
       caddy_systemd_network_dependency: false
       caddy_packages: ["github.com/caddy-dns/lego-deprecated"]
       caddy_config: |
@@ -229,9 +230,7 @@ Example with DigitalOcean DNS for TLS:
             reverse_proxy http://localhost:8080 {
                 header_up Host {http.request.host}
                 header_up X-Real-IP {http.request.remote.host}
-                header_up X-Forwarded-For {http.request.remote.host}
                 header_up X-Forwarded-Port {http.request.port}
-                header_up X-Forwarded-Proto {http.request.scheme}
             }
 
             tls webmaster@example.com {

--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ default:
 caddy_additional_args: ""
 ```
 
-Example for LetsEncrypt staging:
+Example for using Caddyfile configuration format:
 
 ```yaml
-caddy_additional_args: "-ca https://acme-staging.api.letsencrypt.org/directory"
+caddy_additional_args: "--adapter caddyfile"
 ```
 
 ### Use a GitHub OAuth token to request the list of caddy releases

--- a/README.md
+++ b/README.md
@@ -37,10 +37,27 @@ See [Caddyfile docs](https://caddyserver.com/docs/caddyfile). Notice the `|` use
 default:
 
 ```yaml
-caddy_conf_filename: Caddyfile
+caddy_conf_filename: config.json
 caddy_config: |
-  http://localhost:2020
-  respond "Hello, world!"
+  {
+    "apps": {
+      "http": {
+        "servers": {
+          "example": {
+            "listen": [":2020"],
+            "routes": [
+              {
+                "handle": [{
+                  "handler": "static_response",
+                  "body": "Hello, world!"
+                }]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
 ```
 
 If you wish to use a template for the config you can do this:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,10 +4,27 @@ caddy_additional_args: ""
 caddy_bin_dir: /usr/local/bin
 caddy_certs_dir: /etc/ssl/caddy
 caddy_conf_dir: /etc/caddy
-caddy_conf_filename: Caddyfile
+caddy_conf_filename: config.json
 caddy_config: |
-  http://localhost:2020
-  respond "Hello, world!"
+  {
+    "apps": {
+      "http": {
+        "servers": {
+          "example": {
+            "listen": [":2020"],
+            "routes": [
+              {
+                "handle": [{
+                  "handler": "static_response",
+                  "body": "Hello, world!"
+                }]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
 caddy_config_update: true
 caddy_download_timeout: 300
 caddy_environment_files: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -144,6 +144,7 @@
     dest: "{{ caddy_conf_dir }}/{{ caddy_conf_filename }}"
     owner: "{{ caddy_user }}"
     mode: 0640
+    validate: '"{{ caddy_bin_dir }}/caddy" validate --config %s {{ caddy_additional_args }}'
   when:
     - caddy_config_update or not caddy_config_stat.stat.exists
   notify:


### PR DESCRIPTION
As suggested by @Techbrunch in #68 

Example output when validation fails:

```
TASK [caddy : Create caddy config] **********************************************************************
Sunday 13 April 2025  15:00:08 +0100 (0:00:00.979)       0:01:42.305 **********
fatal: [cherry]: FAILED! => {"changed": false, "checksum": "9f7a832ab2373c7b45186f34e1cefdbdbec2f3e6", "exit_status": 1, "msg": "failed to validate", "stderr": "{\"level\":\"info\",\"ts\":1744552810.8547854,\"msg\":\"using config from file\",\"file\":\"/home/joelnb/.ansible/tmp/ansible-tmp-1744552808.9748101-115171-141203831722964/.source\"}\nError: adapting config using caddyfile: /home/joelnb/.ansible/tmp/ansible-tmp-1744552808.9748101-115171-141203831722964/.source:69: unrecognized directive: made_up_directive\n", "stderr_lines": ["{\"level\":\"info\",\"ts\":1744552810.8547854,\"msg\":\"using config from file\",\"file\":\"/home/joelnb/.ansible/tmp/ansible-tmp-1744552808.9748101-115171-141203831722964/.source\"}", "Error: adapting config using caddyfile: /home/joelnb/.ansible/tmp/ansible-tmp-1744552808.9748101-115171-141203831722964/.source:69: unrecognized directive: made_up_directive"], "stdout": "", "stdout_lines": []}
```