### PR TITLE
Replace '+' with '=' in setcap for idempotence

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -162,7 +162,7 @@
 - name: Set capability on the binary file to be able to bind to TCP port <1024
   community.general.capabilities:
     path: "{{ caddy_bin }}"
-    capability: cap_net_bind_service+eip
+    capability: cap_net_bind_service=eip
     state: present
   when: caddy_setcap
   changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"


### PR DESCRIPTION
This fixes the capabilities task resulting in changes every time it executes.
See this issue: https://github.com/ansible/ansible/issues/18911
And specifically this comment: https://github.com/ansible/ansible/issues/18911#issuecomment-583484474